### PR TITLE
Use drupal-theme type for this theme

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "islandora/carapace",
   "description": "An AdaptiveTheme sub-theme customized to optimize the Islandora experience",
-  "type": "drupal-module",
+  "type": "drupal-theme",
   "keywords": ["Drupal", "Islandora"],
   "homepage": "https://github.com/islandora-claw/Carapace",
   "support": {

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "drupal/coder": "*",
     "sebastian/phpcpd": "*"
   },
-  "license": "GPL-2.0+",
+  "license": "GPL-2.0-or-later",
   "authors": [
     {
       "name": "Islandora Foundation",


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora-CLAW/CLAW/issues/779

# What does this Pull Request do?

Changes the type from drupal-module to drupal-theme as in the Drupal composer.json drupal-modules are installed in `./web/modules/contrib`

They are also enabled using `drush pm-enable` and that is only for modules.
```
ubuntu@claw:/var/www/html/drupal/web$ drush pm-enable --help
Enable one or more modules.

Arguments:
  [modules]... A comma delimited list of modules. 

Aliases: en, pm-enable
```

# What's new?

* Does this change require documentation to be updated? no
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository
 (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# How should this be tested?

Not sure the best way to test this.

# Interested parties
@rosiel @Natkeeran @dannylamb 
