### PR TITLE
Removing 5.6 and 7.0 from the test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
   - git -C "$TRAVIS_BUILD_DIR" checkout -b travis-testing
   - cd $DRUPAL_DIR; composer config repositories.local path "$TRAVIS_BUILD_DIR"
   - composer require "islandora/carapace:dev-travis-testing as dev-8.x-1.x" --prefer-source --update-with-dependencies
-  - cd web; drush --uri=127.0.0.1:8282 en -y carapace
+  - cd web; drush --uri=127.0.0.1:8282 then -y carapace
 
 script:
   - $SCRIPT_DIR/line_endings.sh $TRAVIS_BUILD_DIR

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 sudo: true
 language: php
 php:
-  - 5.6
-  - 7.0
   - 7.1
+  - 7.2
 
 matrix:
     fast_finish: true


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora-CLAW/CLAW/issues/890

* Blocking https://github.com/Islandora-CLAW/carapace/pull/5

# What does this Pull Request do?

Removes 5.6 and 7.0 from the test matrix

# How should this be tested?

If Travis is happy, it's good.

# Interested parties
@Islandora-CLAW/committers
