### PR TITLE
Updating adaptivetheme dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 sudo: true
 language: php
 php:
-  - 7.1
   - 7.2
+  - 7.3
 
 services:
   - mysql
@@ -30,7 +30,8 @@ install:
 
 script:
   - $SCRIPT_DIR/line_endings.sh $TRAVIS_BUILD_DIR
-  - phpcs --standard=Drupal --ignore='*.md,*-min.css' --extensions=php,module,inc,install,test,profile,theme,css,info $TRAVIS_BUILD_DIR
+  - phpcs --standard=Drupal --ignore='*.md,*-min.css,*.css' --extensions=php,module,inc,install,test,profile,theme,info $TRAVIS_BUILD_DIR
+  - phpcs --standard=Drupal $TRAVIS_BUILD_DIR/styles/css/custom.css
   - phpcpd --names *.module,*.inc,*.test,*.php $TRAVIS_BUILD_DIR
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ php:
   - 7.1
   - 7.2
 
+services:
+  - mysql
+  
 matrix:
     fast_finish: true
 

--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,7 @@
     }
   ],
   "require": {
-    "drupal/adaptivetheme": "^2.0",
-    "drupal/at_tools": "^2.0",
-    "drupal/layout_plugin": "^1.0@alpha"
+    "drupal/adaptivetheme": "dev-3.x"
   },
   "require-dev": {
     "phpunit/phpunit": "^4.8",


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora-CLAW/CLAW/issues/932

* Test with https://github.com/Islandora-Devops/claw-playbook/pull/143

# What does this Pull Request do?

Updates the dependency on adaptivetheme to get the latest code `dev-3.x`.  We were on 2.0 and need to be on 3.0.  The 3.0 dev branch has an updated conditional which solves an issue when placing blocks with context.

# What's new?
Just updated dependencies

# How should this be tested?

https://github.com/Islandora-Devops/claw-playbook/pull/143

# Interested parties
@Islandora-CLAW/committers
