### PR TITLE
make the header stay centered

### DIFF
--- a/styles/css/components/menu.css
+++ b/styles/css/components/menu.css
@@ -71,7 +71,7 @@
  ============================================================================ */
 .pr-leaderboard {
   /* Mixin */
-  display: inherit;
+  display: flex;
 }
 
 .pr-leaderboard .block-menu {

--- a/styles/css/custom.css
+++ b/styles/css/custom.css
@@ -7,5 +7,5 @@
  * To fix header leaning left
  */
 .pr-leaderboard {
-   display: flex;
+  display: flex;
 }

--- a/styles/css/custom.css
+++ b/styles/css/custom.css
@@ -3,9 +3,3 @@
  * Use this file to override styles if you feel uncomfortable editing
  * component stylesheets.
  ============================================================================ */
-/*
- * To fix header leaning left
- */
-.pr-leaderboard {
-  display: flex;
-}

--- a/styles/css/custom.css
+++ b/styles/css/custom.css
@@ -3,3 +3,9 @@
  * Use this file to override styles if you feel uncomfortable editing
  * component stylesheets.
  ============================================================================ */
+/*
+ * To fix header leaning left
+ */
+.pr-leaderboard {
+   display: flex;
+}


### PR DESCRIPTION
**GitHub Issue**: n/a

# What does this Pull Request do?
Fixes where the header seems to inherit a `block` type. That is needed to allow that header to remain big, but inside we need to be `flex` or we justify left.

# How should this be tested?

Stand up claw-playbook, see how the Log In or My Account & Logout button bar is further left than your Islandora 8 bar.

Pull in this PR.
Clear cache.
Reload page and see it is fixed!

# Interested parties
@Islandora-CLAW/committers
