### PR TITLE
Fix CSS for issue 1328 - Open Seadragon viewer

### DIFF
--- a/styles/css/components/node.css
+++ b/styles/css/components/node.css
@@ -119,6 +119,12 @@
   display: inline-block;
 }
 
+/* Above makes Open Seadragon viewer very small. We undo
+*  that so it takes up the whole of the content area. */
+.field-formatter-openseadragon-image .field-type-image__item {
+  display: initial;
+}
+
 .node .field-type-image__figcaption {
   padding: 0.75rem 0 0 0;
 }


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/1328

# What does this Pull Request do?

Adds CSS to make Open Seadragon viewer display in a larger size.

# What's new?
Added CSS to node.css
/* Above makes Open Seadragon viewer very small. We undo
*  that so it takes up the whole of the content area. */
.field-formatter-openseadragon-image .field-type-image__item {
  display: initial;
}

# Interested parties
@Islandora/8-x-committers
