### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,12 @@ branches:
     - /^8.x/
 
 before_install:
-  - export SCRIPT_DIR=$HOME/islandora/.scripts
+  - export SCRIPT_DIR=$HOME/islandora_ci
   - export DRUPAL_DIR=/opt/drupal
   - export COMPOSER_PATH="/home/travis/.phpenv/versions/$TRAVIS_PHP_VERSION/bin/composer"
 
 install:
-  - git clone https://github.com/Islandora/documentation.git $HOME/islandora
+  - git clone https://github.com/Islandora/islandora_ci.git $HOME/islandora_ci
   - $SCRIPT_DIR/travis_setup_drupal.sh
   - git -C "$TRAVIS_BUILD_DIR" checkout -b travis-testing
   - cd $DRUPAL_DIR


### PR DESCRIPTION
**JIRA Ticket**: Part of https://github.com/Islandora/documentation/pull/1672, which is meant to clear out Islandora/documenation so that it can have looser merging privileges

# What does this Pull Request do?

Uses the newly extracted Islandora/islandora_ci for travis scripts instead of Islandora/documentation.

# How should this be tested?

Travis should be green.

# Interested parties
@Islandora/8-x-committers
