### PR TITLE
Changed adaptive theme to maintained fork.

### DIFF
--- a/carapace.info.yml
+++ b/carapace.info.yml
@@ -5,7 +5,7 @@ type: theme
 'subtheme type': adaptive_subtheme
 layout: page-layout
 description: 'An AdaptiveTheme sub-theme customized to optimize the Islandora experience. <br>Base: at_core (8.x-3.1)'
-core: 8.x
+core_version_requirement: ^8 || ^9
 regions:
   leaderboard: Leaderboard
   header_first: 'Header first'

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     }
   ],
   "require": {
-    "drupal/adaptivetheme": "dev-3.x"
+    "drupal/at_theme": "^1.4"
   },
   "require-dev": {
     "phpunit/phpunit": "^4.8",


### PR DESCRIPTION
Use new fork of adaptive theme, allows carapace to be used with Drupal 9.

@Islandora/8-x-committers
